### PR TITLE
Fehlende Wurzel bei Cauchy-Schwarz-Ungleichung

### DIFF
--- a/vorlesungen/01_intro/slides.tex
+++ b/vorlesungen/01_intro/slides.tex
@@ -249,7 +249,7 @@ Mass für Ähnlichkeit:
 \frametitle{Geometrie}
 \begin{cauchyschwarz}
 \[
-|\langle x,y\rangle| \le \langle x,x\rangle \cdot \langle y,y\rangle
+|\langle x,y\rangle| \le \sqrt{\langle x,x\rangle \cdot \langle y,y\rangle}
 = \|x\|\cdot \|y\|
 \]
 Gleichheit genau dann, wenn $x$ und $y$ linear abhängig sind.


### PR DESCRIPTION
Ein kleiner Fehler welcher mir beim durchsehen der Slides aufgefallen ist. Die Frage ist noch ob man das mit Wurzel oder mit Quadraten bei den anderen Termen darstellen soll.