### PR TITLE
Entferne BOM in polynomials_filter.pgf

### DIFF
--- a/buch/papers/polynomials/images/polynomials_filter.pgf
+++ b/buch/papers/polynomials/images/polynomials_filter.pgf
@@ -1,4 +1,4 @@
-﻿% Filter mit 2 Ebenen
+% Filter mit 2 Ebenen
 
 \usetikzlibrary{shapes,arrows}
 


### PR DESCRIPTION
Wurde von ktikz beim speichern hinzugefügt und bringt leider gewisse
LaTeX Systeme durcheinander.